### PR TITLE
Fix support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Yes. There are a filters you can use to add or remove sections and their metabox
 
 ### Where can I get support?
 
-The WordPress support forums: https://wordpress.org/plugin/support/wp-user-profiles/
+The WordPress support forums: https://wordpress.org/support/plugin/wp-user-profiles.
 
 ### Can I contribute?
 

--- a/readme.txt
+++ b/readme.txt
@@ -49,11 +49,11 @@ Yes. There are a filters you can use to add or remove sections and their metabox
 
 = Where can I get support? =
 
-The WordPress support forums: https://wordpress.org/support/plugin/wp-user-profiles/
+The WordPress support forums: https://wordpress.org/support/plugin/wp-user-profiles.
 
 = Where can I find documentation? =
 
-http://github.com/stuttter/wp-user-profiles/
+http://github.com/stuttter/wp-user-profiles
 
 == Changelog ==
 


### PR DESCRIPTION
That support URL was trying to pull a fast one on those users that only know `support/plugin` and not `plugin/support`.

`support/plugin` it shall be.