### PR TITLE
Fix for wp_user_profiles_add_status_metabox() 

### DIFF
--- a/includes/metaboxes.php
+++ b/includes/metaboxes.php
@@ -32,7 +32,7 @@ function wp_user_profiles_add_status_metabox( $type = '', $user = null ) {
 		'submitdiv',
 		_x( 'Status', 'users user-admin edit screen', 'wp-user-profiles' ),
 		'wp_user_profiles_status_metabox',
-		$types,
+		$type,
 		'side',
 		'high'
 	);


### PR DESCRIPTION
The status wasn't appearing on any profile pages, due to the array of $types being passed to add_meta_box() in wp_user_profiles_add_status_metabox(). 