### PR TITLE
Set the redirect URL after updating a user instead of relying on request URI.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -468,7 +468,7 @@ function wp_user_profiles_save_user() {
 
 	// No errors
 	if ( ! is_wp_error( $errors ) ) {
-		$redirect = add_query_arg( 'updated', true );
+		$redirect = add_query_arg( 'updated', true, get_edit_user_link( $user_id ) );
 
 		if ( ! empty( $wp_http_referer ) ) {
 			$redirect = add_query_arg( 'wp_http_referer', urlencode( $wp_http_referer ), $redirect );


### PR DESCRIPTION
WP User Profiles intercepts all update requests, including those coming from the default core page (user-edit.php). When the request comes from core, it doesn't include the user ID in the query string, which causes the redirect to return an error screen with an 'Invalid user ID.' message.