### PR TITLE
fix for PHP "undefined constant" error when run in WP 4.8-beta2

### DIFF
--- a/wp-user-profiles/includes/sections.php
+++ b/wp-user-profiles/includes/sections.php
@@ -73,7 +73,7 @@ function wp_user_profiles_register_options_section() {
 function wp_user_profiles_register_other_section() {
 
 	// Which hook to check for actions
-	$action = IS_PROFILE_PAGE
+	$action = defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE
 		? 'show_user_profile'
 		: 'edit_user_profile';
 


### PR DESCRIPTION
I just updated a local dev site to WP 4.8-beta2 and got the following PHP error:

`Notice: Use of undefined constant IS_PROFILE_PAGE - assumed 'IS_PROFILE_PAGE' in path/to/site/wp-content/plugins/wp-user-profiles/wp-user-profiles/includes/sections.php on line 78`

This commit prevents that error.

What is odd is that I also updated another site to 4.8-beta2 and I don't get that error on that site.  I don't have time right now to look into why `wp-user-profiles` errors on the one 4.8-beta2 site but not the other.