### PR TITLE
English language option saves correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.DS_Store

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WP User Profiles ===
-Contributors: johnjamesjacoby, stuttter
+Contributors: johnjamesjacoby, stuttter, baden03
 Tags: users, user, profile, edit, metabox
 Requires at least: 4.4
-Tested up to: 4.8
+Tested up to: 5.1.1
 Stable tag: 2.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/wp-user-profiles/includes/metaboxes/account-email.php
+++ b/wp-user-profiles/includes/metaboxes/account-email.php
@@ -2,7 +2,7 @@
 
 /**
  * User Profile Email Metabox
- * 
+ *
  * @package Plugins/Users/Profiles/Metaboxes/Email
  */
 
@@ -23,8 +23,8 @@ function wp_user_profiles_email_metabox( $user = null ) {
 	<table class="form-table">
 		<tr class="user-email-wrap">
 			<th>
-				<label for="email"><?php esc_html_e( 'Email', 'wp-user-profiles' ); ?>
-					<span class="description"><?php esc_html_e( '(required)', 'wp-user-profiles' ); ?></span>
+				<label for="email"><?php _e( 'Email' ); ?>
+					<span class="description"><?php _e( '(required)' ); ?></span>
 				</label>
 			</th>
 			<td>

--- a/wp-user-profiles/includes/metaboxes/account-language.php
+++ b/wp-user-profiles/includes/metaboxes/account-language.php
@@ -19,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
 function wp_user_profiles_language_metabox( $user = null ) {
 
 	// Defaults
+	$languages = get_available_languages();
 	$user_locale = $user->locale;
 	if ( 'en_US' === $user_locale ) {
 		$user_locale = '';
@@ -31,7 +32,7 @@ function wp_user_profiles_language_metabox( $user = null ) {
 	<table class="form-table">
 		<tr class="user-language-wrap">
 			<th scope="row">
-				<label for="locale"><?php esc_html_e( 'Language', 'wp-user-profiles' ); ?></label>
+				<label for="locale"><?php _e( 'Language' ); ?></label>
 			</th>
 			<td><?php
 

--- a/wp-user-profiles/includes/metaboxes/account-language.php
+++ b/wp-user-profiles/includes/metaboxes/account-language.php
@@ -2,7 +2,7 @@
 
 /**
  * User Profile Language Metabox
- * 
+ *
  * @package Plugins/Users/Profiles/Metaboxes/Laguage
  */
 
@@ -19,17 +19,11 @@ defined( 'ABSPATH' ) || exit;
 function wp_user_profiles_language_metabox( $user = null ) {
 
 	// Defaults
-	$languages   = get_available_languages();
 	$user_locale = $user->locale;
-	$fallback    = get_locale();
-
-	// Already en_US
-	if ( 'en_US' === $user->locale ) { 
-		$user_locale = false;
-
-	// Language not available
-	} elseif ( ! in_array( $user->locale, $languages, true ) ) {
-		$user_locale = $fallback;
+	if ( 'en_US' === $user_locale ) {
+		$user_locale = '';
+	} elseif ( '' === $user_locale || ! in_array( $user_locale, $languages, true ) ) {
+		$user_locale = 'site-default';
 	}
 
 	?>
@@ -42,13 +36,16 @@ function wp_user_profiles_language_metabox( $user = null ) {
 			<td><?php
 
 				// Drop it down
-				wp_dropdown_languages( array(
-					'name'                        => 'locale',
-					'id'                          => 'locale',
-					'selected'                    => $user_locale,
-					'languages'                   => $languages,
-					'show_available_translations' => false
-				) );
+				wp_dropdown_languages(
+					array(
+						'name'                        => 'locale',
+						'id'                          => 'locale',
+						'selected'                    => $user_locale,
+						'languages'                   => $languages,
+						'show_available_translations' => false,
+						'show_option_site_default'    => true,
+					)
+				);
 
 				?>
 			</td>

--- a/wp-user-profiles/includes/metaboxes/account-password.php
+++ b/wp-user-profiles/includes/metaboxes/account-password.php
@@ -2,7 +2,7 @@
 
 /**
  * User Profile Password Metabox
- * 
+ *
  * @package Plugins/Users/Profiles/Metaboxes/Password
  */
 
@@ -21,38 +21,38 @@ function wp_user_profiles_password_metabox() {
 
 	<table class="form-table">
 		<tr id="password" class="user-pass1-wrap">
-			<th><label for="pass1"><?php esc_html_e( 'New Password', 'wp-user-profiles' ); ?></label></th>
+			<th><label for="pass1"><?php _e( 'New Password' ); ?></label></th>
 			<td>
 				<input class="hidden" value=" " /><!-- #24364 workaround -->
-				<button type="button" class="button button-secondary wp-generate-pw hide-if-no-js"><?php esc_html_e( 'Generate Password', 'wp-user-profiles' ); ?></button>
+				<button type="button" class="button button-secondary wp-generate-pw hide-if-no-js"><?php _e( 'Generate Password' ); ?></button>
 				<div class="wp-pwd hide-if-js">
 					<span class="password-input-wrapper">
 						<input type="password" name="pass1" id="pass1" class="regular-text" value="" autocomplete="off" data-pw="<?php echo esc_attr( wp_generate_password( 24 ) ); ?>" aria-describedby="pass-strength-result" />
 					</span>
-					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
+					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php _e( 'Hide password' ); ?>">
 						<span class="dashicons dashicons-hidden"></span>
-						<span class="text"><?php esc_html_e( 'Hide', 'wp-user-profiles' ); ?></span>
+						<span class="text"><?php _e( 'Hide' ); ?></span>
 					</button>
-					<button type="button" class="button button-secondary wp-cancel-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Cancel password change' ); ?>">
-						<span class="text"><?php esc_html_e( 'Cancel', 'wp-user-profiles' ); ?></span>
+					<button type="button" class="button button-secondary wp-cancel-pw hide-if-no-js" data-toggle="0" aria-label="<?php _e( 'Cancel password change' ); ?>">
+						<span class="text"><?php _e( 'Cancel' ); ?></span>
 					</button>
 					<div style="display:none" id="pass-strength-result" aria-live="polite"></div>
 				</div>
 			</td>
 		</tr>
 		<tr class="user-pass2-wrap hide-if-js">
-			<th scope="row"><label for="pass2"><?php esc_html_e( 'Repeat New Password', 'wp-user-profiles' ); ?></label></th>
+			<th scope="row"><label for="pass2"><?php _e( 'Repeat New Password' ); ?></label></th>
 			<td>
 				<input name="pass2" type="password" id="pass2" class="regular-text" value="" autocomplete="off" />
-				<p class="description"><?php esc_html_e( 'Type your new password again.', 'wp-user-profiles' ); ?></p>
+				<p class="description"><?php _e( 'Type your new password again.' ); ?></p>
 			</td>
 		</tr>
 		<tr class="pw-weak">
-			<th><?php esc_html_e( 'Confirm Password', 'wp-user-profiles' ); ?></th>
+			<th><?php _e( 'Confirm Password' ); ?></th>
 			<td>
 				<label>
 					<input type="checkbox" name="pw_weak" class="pw-checkbox" />
-					<?php esc_html_e( 'Confirm use of weak password', 'wp-user-profiles' ); ?>
+					<?php _e( 'Confirm use of weak password' ); ?>
 				</label>
 			</td>
 		</tr>

--- a/wp-user-profiles/includes/metaboxes/account-sessions.php
+++ b/wp-user-profiles/includes/metaboxes/account-sessions.php
@@ -27,11 +27,11 @@ function wp_user_profiles_session_metabox( $user = null ) {
 		<?php if ( ( true === $profile ) && count( $sessions->get_all() ) === 1 ) : ?>
 
 			<tr class="user-sessions-wrap hide-if-no-js">
-				<th><?php esc_html_e( 'Sessions', 'wp-user-profiles' ); ?></th>
+				<th><?php _e( 'Sessions' ); ?></th>
 				<td aria-live="assertive">
-					<div class="destroy-sessions"><button type="button" disabled class="button button-secondary"><?php esc_html_e( 'Log Out Everywhere Else', 'wp-user-profiles' ); ?></button></div>
+					<div class="destroy-sessions"><button type="button" disabled class="button button-secondary"><?php _e( 'Log Out Everywhere Else' ); ?></button></div>
 					<p class="description">
-						<?php esc_html_e( 'You are only logged in at this location.' ); ?>
+						<?php _e( 'You are only logged in at this location.' ); ?>
 					</p>
 				</td>
 			</tr>
@@ -39,11 +39,11 @@ function wp_user_profiles_session_metabox( $user = null ) {
 		<?php elseif ( ( true === $profile ) && count( $sessions->get_all() ) > 1 ) : ?>
 
 			<tr class="user-sessions-wrap hide-if-no-js">
-				<th><?php esc_html_e( 'Sessions', 'wp-user-profiles' ); ?></th>
+				<th><?php _e( 'Sessions' ); ?></th>
 				<td aria-live="assertive">
-					<div class="destroy-sessions"><button type="button" class="button button-secondary" id="destroy-sessions"><?php esc_html_e( 'Log Out Everywhere Else', 'wp-user-profiles' ); ?></button></div>
+					<div class="destroy-sessions"><button type="button" class="button button-secondary" id="destroy-sessions"><?php _e( 'Log Out Everywhere Else' ); ?></button></div>
 					<p class="description">
-						<?php esc_html_e( 'Did you lose your phone or leave your account logged in at a public computer? You can log out everywhere else, and stay logged in here.', 'wp-user-profiles' ); ?>
+						<?php _e( 'Did you lose your phone or leave your account logged in at a public computer? You can log out everywhere else, and stay logged in here.' ); ?>
 					</p>
 				</td>
 			</tr>
@@ -51,13 +51,13 @@ function wp_user_profiles_session_metabox( $user = null ) {
 		<?php elseif ( ( false === $profile ) && $sessions->get_all() ) : ?>
 
 			<tr class="user-sessions-wrap hide-if-no-js">
-				<th><?php esc_html_e( 'Sessions', 'wp-user-profiles' ); ?></th>
+				<th><?php _e( 'Sessions' ); ?></th>
 				<td>
-					<p><button type="button" class="button button-secondary" id="destroy-sessions"><?php esc_html_e( 'Log Out Everywhere', 'wp-user-profiles' ); ?></button></p>
+					<p><button type="button" class="button button-secondary" id="destroy-sessions"><?php _e( 'Log Out Everywhere' ); ?></button></p>
 					<p class="description">
 						<?php
 						/* translators: 1: User's display name. */
-						printf( esc_html__( 'Log %s out of all locations.', 'wp-user-profiles' ), $user->display_name );
+						printf( __( 'Log %s out of all locations.' ), $user->display_name );
 						?>
 					</p>
 				</td>
@@ -66,12 +66,12 @@ function wp_user_profiles_session_metabox( $user = null ) {
 		<?php elseif ( ( false === $profile ) && ! $sessions->get_all() ) : ?>
 
 			<tr class="user-sessions-wrap hide-if-no-js">
-				<th><?php esc_html_e( 'Inactive', 'wp-user-profiles' ); ?></th>
+				<th><?php _e( 'Inactive' ); ?></th>
 				<td>
 					<p>
 						<?php
 						/* translators: 1: User's display name. */
-						printf( esc_html__( '%s has not logged in yet.', 'wp-user-profiles' ), $user->display_name );
+						printf( __( '%s has not logged in yet.' ), $user->display_name );
 						?>
 					</p>
 				</td>

--- a/wp-user-profiles/includes/sections/account.php
+++ b/wp-user-profiles/includes/sections/account.php
@@ -114,6 +114,11 @@ class WP_User_Profile_Account_Section extends WP_User_Profile_Section {
 		// Checking locale
 		if ( isset( $_POST['locale'] ) ) {
 			$user->locale = sanitize_text_field( wp_unslash( $_POST['locale'] ) );
+
+			//empty is en_US
+			if ( empty( $user->locale ) ) {
+				$user->locale = 'en_US';
+			}
 		}
 
 		// Checking email address


### PR DESCRIPTION
When the locale is updated, if English is selected, an empty value is being checked for and if found sets the value to en_US as WordPress does.

Also, some WP standard fields like email, password and language now use standard WP translations.