### PR TITLE
Fix the sites list

### DIFF
--- a/wp-user-profiles/includes/metaboxes/sites-list.php
+++ b/wp-user-profiles/includes/metaboxes/sites-list.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * @param WP_User $user The WP_User object to be edited.
  */
 function wp_user_profiles_sites_metabox( $user = null ) {
+	require_once dirname( __DIR__ ) . '/sites-list-table.php';
 
 	$is_network_admin = current_user_can( 'manage_sites' );
 	$all_sites = $is_network_admin && ! empty( $_GET['all_sites'] );
@@ -27,7 +28,9 @@ function wp_user_profiles_sites_metabox( $user = null ) {
 
 	// Force screen to setup list table
 	set_current_screen( 'network-sites' );
-	$wp_list_table = _get_list_table( 'WP_MS_Sites_List_Table' );
+	$wp_list_table = new WP_User_Profiles_Sites_List_Table( array(
+		'screen' => get_current_screen(),
+	) );
 
 	// Override sites query
 	if ( $all_sites || ! empty( $sites ) ) {

--- a/wp-user-profiles/includes/metaboxes/sites-list.php
+++ b/wp-user-profiles/includes/metaboxes/sites-list.php
@@ -167,6 +167,8 @@ function wp_user_profiles_filter_sites_columns( $columns = array() ) {
 function wp_user_profiles_filter_views( $views = array() ) {
 	$all_sites = ! empty( $_GET['all_sites'] );
 
+	$views = array();
+
 	$views['assigned'] = "<a href='" . esc_url( add_query_arg( 'all_sites', 0 ) ) . "#sites'" . ( ! $all_sites ? 'class="current"' : '' ) . '>' . esc_html__( 'Assigned', 'wp-user-profiles' ) . '</a>';
 	$views['all'] = "<a href='" . esc_url( add_query_arg( 'all_sites', 1 ) ) . "#sites'" . ( $all_sites ? 'class="current"' : '' ) . '>' . esc_html__( 'All Sites', 'wp-user-profiles' ) . '</a>';
 

--- a/wp-user-profiles/includes/sites-list-table.php
+++ b/wp-user-profiles/includes/sites-list-table.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * User Profile Sites List Table
+ *
+ * @package Plugins/Users/Profiles/SitesList
+ */
+
+require_once ABSPATH . 'wp-admin/includes/class-wp-ms-sites-list-table.php';
+
+/**
+ * Core class used to implement displaying sites in a list table within a user profile.
+ */
+class WP_User_Profiles_Sites_List_Table extends WP_MS_Sites_List_Table {
+
+	/**
+	 * Handles the checkbox column output.
+	 *
+	 * @param array $blog Current site.
+	 */
+	public function column_cb( $blog ) {
+		$blogname = untrailingslashit( $blog['domain'] . $blog['path'] );
+		?>
+		<label class="screen-reader-text" for="blog_<?php echo esc_attr( $blog['blog_id'] ); ?>">
+			<?php
+			/* translators: %s: Site URL. */
+			printf( __( 'Select %s' ), $blogname );
+			?>
+		</label>
+		<input type="checkbox" id="blog_<?php echo esc_attr( $blog['blog_id'] ); ?>" name="allblogs[]" value="<?php echo esc_attr( $blog['blog_id'] ); ?>" />
+		<?php
+	}
+
+}


### PR DESCRIPTION
There are two issues with the Sites section on the Sites tab of a user profile:

1. The status filters for sites don't work (eg. `Public`, `Archived`), they point to `network/sites.php`
2. The main site doesn't get a checkbox due to the `! is_main_site()` condition in `WP_MS_Sites_List_Table::column_cb()`, which means you can't hit the select all checkbox and select all sites.

This change removes the broken filter links and overrides core's `column_cb()` method in our own list table to get around those issues.