### PR TITLE
Use the same logic as WordPress core when saving the locale field

### DIFF
--- a/wp-user-profiles/includes/sections/account.php
+++ b/wp-user-profiles/includes/sections/account.php
@@ -113,12 +113,17 @@ class WP_User_Profile_Account_Section extends WP_User_Profile_Section {
 
 		// Checking locale
 		if ( isset( $_POST['locale'] ) ) {
-			$user->locale = sanitize_text_field( wp_unslash( $_POST['locale'] ) );
+			$locale = sanitize_text_field( $_POST['locale'] );
 
-			//empty is en_US
-			if ( empty( $user->locale ) ) {
-				$user->locale = 'en_US';
+			if ( 'site-default' === $locale ) {
+				$locale = '';
+			} elseif ( '' === $locale ) {
+				$locale = 'en_US';
+			} elseif ( ! in_array( $locale, get_available_languages(), true ) ) {
+				$locale = '';
 			}
+
+			$user->locale = $locale;
 		}
 
 		// Checking email address


### PR DESCRIPTION
Fixes #33.

The issue is that WP User Profiles simply sets the user's locale to the value of the submitted field, but it needs to take into account the potential `site-default` value.

The code in this fix is taken directly from WordPress core:

https://github.com/WordPress/wordpress-develop/blob/d0f4f20df5cc7f1820d77431cdbdd0e91b5e117b/src/wp-admin/includes/user.php#L115-L126