### PR TITLE
Take into account other possible values for `$pagenow` when saving a profile

### DIFF
--- a/wp-user-profiles/includes/common.php
+++ b/wp-user-profiles/includes/common.php
@@ -322,9 +322,14 @@ function wp_user_profiles_save_user() {
 		return;
 	}
 
+	// Bail if not processing the user editing page
+	if ( ! in_array( $pagenow, array( 'users.php', 'admin.php' ), true ) ) {
+		return;
+	}
+
 	// Bail if not a registered section
 	$sections = wp_list_pluck( wp_user_profiles_sections(), 'id' );
-	if ( ! ( 'users.php' === $pagenow && isset( $_REQUEST['page'] ) && in_array( $_REQUEST['page'], $sections ) ) ) {
+	if ( ! ( isset( $_REQUEST['page'] ) && in_array( $_REQUEST['page'], $sections ) ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #34.

When a user cannot list users, the page for editing your own profile is `admin.php`, not `users.php`. Ref:

https://github.com/stuttter/wp-user-profiles/blob/74f721e6cc480c3564a6fe304650bff009a434d7/wp-user-profiles/includes/common.php#L69-L72

This fixes all that jazz.