### PR TITLE
Add the language icon to match the one in WP core

### DIFF
--- a/wp-user-profiles/includes/metaboxes/account-language.php
+++ b/wp-user-profiles/includes/metaboxes/account-language.php
@@ -32,7 +32,10 @@ function wp_user_profiles_language_metabox( $user = null ) {
 	<table class="form-table">
 		<tr class="user-language-wrap">
 			<th scope="row">
-				<label for="locale"><?php _e( 'Language' ); ?></label>
+				<label for="locale">
+					<?php _e( 'Language' ); ?>
+					<span class="dashicons dashicons-translation" aria-hidden="true"></span>
+				</label>
 			</th>
 			<td><?php
 


### PR DESCRIPTION
Fixes #32.

![](https://user-images.githubusercontent.com/208434/91081754-e3f87980-e647-11ea-801a-1b8b225d25ee.png)
