### PR TITLE
Remove all row action links from the Sites tab

### DIFF
--- a/wp-user-profiles/includes/sites-list-table.php
+++ b/wp-user-profiles/includes/sites-list-table.php
@@ -31,4 +31,15 @@ class WP_User_Profiles_Sites_List_Table extends WP_MS_Sites_List_Table {
 		<?php
 	}
 
+	/**
+	 * Removes all row action links as they're not needed for this context.
+	 *
+	 * @param object $blog        Site being acted upon.
+	 * @param string $column_name Current column name.
+	 * @param string $primary     Primary column name.
+	 * @return string Row actions output for sites.
+	 */
+	protected function handle_row_actions( $blog, $column_name, $primary ) {
+		return '';
+	}
 }


### PR DESCRIPTION
Fixes #38 by removing the action links entirely from our custom list table that's used for the Sites tab.

Screenshot:

<img alt="" src="https://user-images.githubusercontent.com/208434/93687148-617ea080-fab3-11ea-9612-f3f237093da4.png">
