### PR TITLE
Issue/43 - Add sub-navigation

### DIFF
--- a/wp-user-profiles.php
+++ b/wp-user-profiles.php
@@ -89,5 +89,5 @@ function wp_user_profiles_get_plugin_url() {
 function wp_user_profiles_get_asset_version() {
 	return defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG
 		? time()
-		: 202010210002;
+		: 202011020001;
 }

--- a/wp-user-profiles/assets/css/user-profiles.css
+++ b/wp-user-profiles/assets/css/user-profiles.css
@@ -21,3 +21,81 @@
 #wp-user-profiles-page #pass1-text {
 	width: 20em;
 }
+
+
+/* Secondary Nav
+-------------------------------------------------------------- */
+
+#profile-subnav {
+	margin: 0 0px 10px 0;
+	width: 100%;
+	border-bottom: 1px solid #ccc;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+#profile-subnav a {
+	padding: 13px;
+	display: block;
+}
+
+#profile-subnav a.current {
+	border-bottom: 4px solid #000;
+	padding-bottom: 9px;
+}
+
+/* Fresh */
+.admin-color-fresh #profile-subnav a.current {
+	border-bottom-color: #00a0d2;
+}
+
+/* Blue */
+.admin-color-blue #profile-subnav a.current {
+	border-bottom-color: #096484;
+}
+
+/* Coffee */
+.admin-color-coffee #profile-subnav a.current {
+	border-bottom-color: #096484;
+}
+
+/* Ectoplasm */
+.admin-color-ectoplasm #profile-subnav a.current {
+	border-bottom-color: #a3b745;
+}
+
+/* Midnight */
+.admin-color-midnight #profile-subnav a.current {
+	border-bottom-color: #26292c;
+}
+
+/* Modern */
+.admin-color-modern #profile-subnav a.current {
+	border-bottom-color: #3858e9;
+}
+
+/* Ocean */
+.admin-color-ocean #profile-subnav a.current {
+	border-bottom-color: #627c83;
+}
+
+/* Sunrise */
+.admin-color-sunrise #profile-subnav a.current {
+	border-bottom-color: #be3631;
+}
+
+/* Light */
+.admin-color-light #profile-subnav a.current {
+	border-bottom-color: #888;
+}
+
+/* bbPress Color Schemes */
+
+/* Evergreen */
+.admin-color-evergreen #profile-subnav a.current {
+	border-bottom-color: #36533f;
+}
+
+/* Mint */
+.admin-color-mint #profile-subnav a.current {
+	border-bottom-color: #4f6d59;
+}

--- a/wp-user-profiles/includes/admin.php
+++ b/wp-user-profiles/includes/admin.php
@@ -475,7 +475,7 @@ function wp_user_profiles_admin_subnav( $user = null ) {
 	}
 
 	// Add the user ID to query arguments when not editing yourself
-	$query_args = wp_user_profiles_admin_default_query_args();
+	$query_args = wp_user_profiles_admin_default_query_args( $user );
 
 	// Get the current page
 	$page       = wp_user_profiles_admin_current_page();

--- a/wp-user-profiles/includes/admin.php
+++ b/wp-user-profiles/includes/admin.php
@@ -93,8 +93,8 @@ function wp_user_profiles_admin_menus() {
 		// Re-add new "Your Profile" submenu
 		add_submenu_page(
 			$file,
-			esc_html__( 'Your Profile', 'wp-user-profiles' ),
-			esc_html__( 'Your Profile', 'wp-user-profiles' ),
+			esc_html__( 'Profile', 'wp-user-profiles' ),
+			esc_html__( 'Profile', 'wp-user-profiles' ),
 			'read',
 			'profile',
 			$callback

--- a/wp-user-profiles/includes/common.php
+++ b/wp-user-profiles/includes/common.php
@@ -168,6 +168,32 @@ function wp_user_profiles_sort_sections( $hip, $hop ) {
 }
 
 /**
+ * Filter sections
+ *
+ * @since 3.0.0
+ *
+ * @param array $args
+ * @param string $operator
+ * @return object|array
+ */
+function wp_user_profiles_filter_sections( $args = array(), $operator = 'AND' ) {
+
+	// Get all sections
+	$all    = wp_user_profiles_sections();
+
+	// Filter sections
+	$retval = wp_list_filter( $all, $args, $operator );
+
+	// Return the object if only 1 item was found and filtering by ID
+	if ( ( 1 === count( $retval ) ) && array_key_exists( 'id', $args ) ) {
+		$retval = reset( $retval );
+	}
+
+	// Filter & return
+	return apply_filters( 'wp_user_profiles_filter_sections', $retval, $args, $operator, $all );
+}
+
+/**
  * Get profile section slugs
  *
  * This function exists because hooknames change based on two unique factors:

--- a/wp-user-profiles/includes/hooks.php
+++ b/wp-user-profiles/includes/hooks.php
@@ -64,3 +64,7 @@ add_action( 'wp_ajax_nopriv_wp_user_profiles_export_roles', 'wp_user_profiles_ex
 
 // Back compat ("Other" section)
 add_filter( 'wp_user_profiles_show_other_section', 'wp_user_profiles_has_profile_actions' );
+
+// Nav & Subnav
+add_action( 'wp_user_profiles_nav_actions', 'wp_user_profiles_admin_nav',    12 );
+add_action( 'wp_user_profiles_nav_actions', 'wp_user_profiles_admin_subnav', 14 );

--- a/wp-user-profiles/includes/metaboxes/profile-name.php
+++ b/wp-user-profiles/includes/metaboxes/profile-name.php
@@ -20,7 +20,7 @@ function wp_user_profiles_name_metabox( $user = null ) {
 
 	if ( wp_is_profile_page() ) {
 		/**
-		 * Fires after the 'Personal Options' settings table on the 'Your Profile' editing screen.
+		 * Fires after the 'Personal Options' settings table on the 'Profile' editing screen.
 		 *
 		 * The action only fires if the current user is editing their own profile.
 		 *

--- a/wp-user-profiles/includes/sections/base.php
+++ b/wp-user-profiles/includes/sections/base.php
@@ -71,6 +71,24 @@ class WP_User_Profile_Section {
 	public $order = '70';
 
 	/**
+	 * Parent page ID (if not a primary page)
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public $parent = '';
+
+	/**
+	 * Name of the subsection if prepended.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public $subname = '';
+
+	/**
 	 * Errors
 	 *
 	 * @since 0.2.0
@@ -113,12 +131,14 @@ class WP_User_Profile_Section {
 		$this->errors = new WP_Error();
 
 		// Set object properties
-		$this->id    = isset( $args[0]['id']    ) ? $args[0]['id']    : '';
-		$this->slug  = isset( $args[0]['slug']  ) ? $args[0]['slug']  : '';
-		$this->name  = isset( $args[0]['name']  ) ? $args[0]['name']  : '';
-		$this->icon  = isset( $args[0]['icon']  ) ? $args[0]['icon']  : '';
-		$this->order = isset( $args[0]['order'] ) ? $args[0]['order'] : '';
-		$this->cap   = isset( $args[0]['cap']   ) ? $args[0]['cap']   : '';
+		$this->id      = isset( $args[0]['id']      ) ? $args[0]['id']      : '';
+		$this->slug    = isset( $args[0]['slug']    ) ? $args[0]['slug']    : '';
+		$this->name    = isset( $args[0]['name']    ) ? $args[0]['name']    : '';
+		$this->icon    = isset( $args[0]['icon']    ) ? $args[0]['icon']    : '';
+		$this->order   = isset( $args[0]['order']   ) ? $args[0]['order']   : '';
+		$this->cap     = isset( $args[0]['cap']     ) ? $args[0]['cap']     : '';
+		$this->parent  = isset( $args[0]['parent']  ) ? $args[0]['parent']  : '';
+		$this->subname = isset( $args[0]['subname'] ) ? $args[0]['subname'] : '';
 
 		// Setup the profile section
 		$GLOBALS['wp_user_profile_sections'][ $this->id ] = $this;


### PR DESCRIPTION
* Alters Section Base class to include "parent" and "subname" properties, used for a brief tree climb and overriding the text of a prepended subnav item
* Adds helper functions to abstract some duplication between primary-nav and secondary-nav
* Wrap navs in their own div, as well as output buffers to reduce some UI jumpiness
* Move the admin notices action underneath the H1 to limit some jumpiness
* Adds CSS styling for the sub-nav

Fixes #43 