### PR TITLE
Issue/18 - BuddyPress: unhook broken BP_Member_Admin:profile_nav.

### DIFF
--- a/wp-user-profiles/includes/capabilities.php
+++ b/wp-user-profiles/includes/capabilities.php
@@ -109,7 +109,12 @@ function wp_user_profiles_current_user_can_edit( $user_id = 0 ) {
  * @param type $user
  */
 function wp_user_profiles_old_profile_redirect() {
-	wp_safe_redirect( get_dashboard_url() );
+
+	// Get the redirect URL
+	$url = get_edit_profile_url( get_current_user_id() );
+
+	// Do the redirect
+	wp_safe_redirect( $url );
 	exit;
 }
 

--- a/wp-user-profiles/includes/common.php
+++ b/wp-user-profiles/includes/common.php
@@ -476,3 +476,35 @@ function wp_user_profiles_has_profile_actions() {
 	// Return true/false
 	return $retval;
 }
+
+/**
+ * Maybe unhook the BuddyPress Profile Navigation hook
+ *
+ * BuddyPress hooks into 'show_user_profile' and 'edit_user_profile' for
+ * displaying its custom UI, it conflicts with ours, so the best thing we can do
+ * is avoid the situation completely.
+ *
+ * @since 2.4.0
+ */
+function wp_user_profiles_unhook_bp_profile_nav() {
+
+	// Bail if no BuddyPress
+	if ( ! function_exists( 'buddypress' ) ) {
+		return;
+	}
+
+	// Get BuddyPress Profile Navigation hook
+	$bp = buddypress();
+
+	// Bail if no Member Admin
+	if ( empty( $bp->members->admin ) ) {
+		return;
+	}
+
+	// Get the hook callback
+	$tag = array( $bp->members->admin, 'profile_nav' );
+
+	// Remove the actions
+	remove_action( 'show_user_profile', $tag, 99 );
+	remove_action( 'edit_user_profile', $tag, 99 );
+}

--- a/wp-user-profiles/includes/hooks.php
+++ b/wp-user-profiles/includes/hooks.php
@@ -68,3 +68,6 @@ add_filter( 'wp_user_profiles_show_other_section', 'wp_user_profiles_has_profile
 // Nav & Subnav
 add_action( 'wp_user_profiles_nav_actions', 'wp_user_profiles_admin_nav',    12 );
 add_action( 'wp_user_profiles_nav_actions', 'wp_user_profiles_admin_subnav', 14 );
+
+// BuddyPress
+add_action( 'bp_init', 'wp_user_profiles_unhook_bp_profile_nav' );


### PR DESCRIPTION
This commit prevents the BuddyPress profile navigation UI from triggering our "Other" compatibility section, and also fixes a related profile.php redirection issue.

See #18.