### PR TITLE
Correct the `$user` parameter when calling wp_get_user_contact_methods()

### DIFF
--- a/wp-user-profiles/includes/sections/profile.php
+++ b/wp-user-profiles/includes/sections/profile.php
@@ -52,7 +52,7 @@ class WP_User_Profile_Profile_Section extends WP_User_Profile_Section {
 		);
 
 		// Contact, if methods are registered
-		if ( wp_get_user_contact_methods( $user ) ) {
+		if ( wp_get_user_contact_methods( $user['user'] ) ) {
 			add_meta_box(
 				'contact',
 				_x( 'Contact', 'users user-admin edit screen', 'wp-user-profiles' ),


### PR DESCRIPTION
The `wp_get_user_contact_methods()` function expects an optional `WP_User` object as its second parameter.

Here, WP User Profiles is passing an array instead. The `user` element of this array contains the `WP_User` object.