### PR TITLE
Status: Refactor the way user_status and super-admin are saved.

### DIFF
--- a/wp-user-profiles/includes/capabilities.php
+++ b/wp-user-profiles/includes/capabilities.php
@@ -184,3 +184,47 @@ function wp_user_profiles_user_supports( $thing = '', $user_id = 0 ) {
 	// Filter & return
 	return apply_filters( '', $retval, $thing, $user_id );
 }
+
+/**
+ * Grant or revoke super admin status
+ *
+ * This function exists to assist with updating whether a user is an
+ * administrator to the entire installation.
+ *
+ * @since 2.5.1
+ *
+ * @param WP_User $user
+ */
+function wp_user_profiles_save_user_super_admin( $user = null ) {
+
+	// Bail if global is set
+	if ( isset( $GLOBALS['super_admins'] ) ) {
+		return;
+	}
+
+	// Bail if editing their own profile
+	if ( wp_is_profile_page() ) {
+		return;
+	}
+
+	// Bail if not in network admin
+	if ( ! is_multisite() || ! is_network_admin() ) {
+		return;
+	}
+
+	// Bail if current user cannot manage network options
+	if ( ! current_user_can( 'manage_network_options' ) ) {
+		return;
+	}
+
+	// Determine which function to call
+	$func = empty( $_POST['super_admin'] )
+		? 'revoke_super_admin'
+		: 'grant_super_admin';
+
+	// Grant or revoke super admin status if requested.
+	call_user_func( $func, $user->ID );
+
+	// Return the user
+	return $user;
+}

--- a/wp-user-profiles/includes/hooks.php
+++ b/wp-user-profiles/includes/hooks.php
@@ -42,9 +42,10 @@ add_action( 'wp_user_profiles_add_meta_boxes', 'wp_user_profiles_add_status_meta
 add_action( 'wp_user_profiles_admin_notices', 'wp_user_profiles_admin_notices' );
 
 // Admin Saving
-add_action( 'admin_init',                         'wp_user_profiles_save_user'           );
-add_action( 'wp_user_profiles_get_admin_notices', 'wp_user_profiles_save_user_notices'   );
-add_filter( 'wp_user_profiles_save',              'wp_user_profiles_update_global_admin' );
+add_action( 'admin_init',                                'wp_user_profiles_save_user'             );
+add_filter( 'wp_user_profiles_save',                     'wp_user_profiles_save_user_status'      );
+add_action( 'wp_user_profiles_get_admin_notices',        'wp_user_profiles_save_user_notices'     );
+add_action( 'wp_user_profiles_save_permissions_section', 'wp_user_profiles_save_user_super_admin' );
 
 // Capabilities
 add_filter( 'map_meta_cap',     'wp_user_profiles_map_meta_cap', 10, 4 );

--- a/wp-user-profiles/includes/sections/base.php
+++ b/wp-user-profiles/includes/sections/base.php
@@ -190,8 +190,8 @@ class WP_User_Profile_Section {
 	 */
 	public function action_save( $user = null ) {
 
-		// Bail if ID is empty or object is not a user
-		if ( empty( $this->id ) || ! is_a( $user, 'WP_User' ) ) {
+		// Bail if ID is empty
+		if ( empty( $this->id ) ) {
 			return $user;
 		}
 
@@ -256,11 +256,6 @@ class WP_User_Profile_Section {
 		// Return errors if there are any
 		if ( is_wp_error( $user ) && $user->get_error_codes() ) {
 			return $user;
-		}
-
-		// Maybe save user status
-		if ( ! empty( $_POST['user_status'] ) ) {
-			wp_user_profiles_update_user_status( $user, sanitize_key( $_POST['user_status'] ) );
 		}
 
 		// Update the user in the database


### PR DESCRIPTION
This commit includes the following intended changes:

* Move user_status save out of Base class and into its own global function & hook. Subclasses should not risk executing this code.
* Move super-admin grant/revoke code out of status.php and into capabilities.php
* Rename wp_user_profiles_update_global_admin() to wp_user_profiles_save_user_super_admin() to better match existing patterns
* Hook newly named function to Permissions-Only section hook so that it only fires on that section
* Moves make_spam and make_ham actions into wp_user_profiles_transition_user_status
* When making spam or ham, only do so if not already spam or ham, to prevent overspamming and overhamming
* Remove a few is_a() checks that aren't actually necessary, since this gets done further downstream
* Fixes a forever-bug causing wp_user_profiles_update_user_status() not to work on single-site installs :picard-face-palm:
* General logical order-of-operations fixes to prevent doing status & super-admin related things when they were not necessary

Fixes #56.