### PR TITLE
Role list table improvements

### DIFF
--- a/wp-user-profiles/includes/metaboxes/sites-list.php
+++ b/wp-user-profiles/includes/metaboxes/sites-list.php
@@ -193,7 +193,7 @@ function wp_user_profiles_filter_role_column( $column_name = '', $blog_id = 0 ) 
  *
  * @param array|null $site_ids List of site IDs to grab roles from
  *
- * @return array|bool|mixed
+ * @return string[] Array of user role display names keyed by role.
  */
 function wp_user_profiles_get_common_user_roles( array $site_ids = null ) {
 

--- a/wp-user-profiles/includes/metaboxes/sites-list.php
+++ b/wp-user-profiles/includes/metaboxes/sites-list.php
@@ -61,7 +61,6 @@ function wp_user_profiles_sites_metabox( $user = null ) {
 
 	// Filter action links
 	add_filter( 'manage_sites_action_links',   'wp_user_profiles_filter_sites_action_links', 10, 2 );
-	add_filter( 'wpmu_blogs_columns',          'wp_user_profiles_filter_sites_columns'      );
 	add_filter( 'views_network-sites',         'wp_user_profiles_filter_views'              );
 	add_filter( 'bulk_actions-network-sites',  'wp_user_profiles_filter_bulk_actions'       );
 	add_filter( 'manage_sites_custom_column',  'wp_user_profiles_filter_role_column', 10, 2 );
@@ -73,7 +72,6 @@ function wp_user_profiles_sites_metabox( $user = null ) {
 
 	// Unfilter action links
 	remove_filter( 'manage_sites_action_links', 'wp_user_profiles_filter_sites_action_links' );
-	remove_filter( 'wpmu_blogs_columns',        'wp_user_profiles_filter_sites_columns'      );
 
 	// After
 	do_action( __FUNCTION__ . '_after', $user );
@@ -136,28 +134,6 @@ function wp_user_profiles_filter_sites_action_links( $links = array(), $blog_id 
 	}
 
 	return $links;
-}
-
-/**
- * Unset the checkbox column in user profiles
- *
- * @since 1.0.0
- *
- * @param array $columns
- * @return array
- */
-function wp_user_profiles_filter_sites_columns( $columns = array() ) {
-	$is_network_admin = current_user_can( 'manage_sites' );
-
-	if ( $is_network_admin ) {
-		$columns['roles'] = esc_html__( 'Roles', 'wp-user-profiles' );
-	} else {
-		unset( $columns['cb'] );
-	}
-
-	unset( $columns['lastupdated'], $columns['registered'] );
-
-	return $columns;
 }
 
 /**

--- a/wp-user-profiles/includes/metaboxes/sites-list.php
+++ b/wp-user-profiles/includes/metaboxes/sites-list.php
@@ -60,7 +60,6 @@ function wp_user_profiles_sites_metabox( $user = null ) {
 	do_action( __FUNCTION__ . '_before', $user );
 
 	// Filter action links
-	add_filter( 'manage_sites_action_links',   'wp_user_profiles_filter_sites_action_links', 10, 2 );
 	add_filter( 'views_network-sites',         'wp_user_profiles_filter_views'              );
 	add_filter( 'bulk_actions-network-sites',  'wp_user_profiles_filter_bulk_actions'       );
 	add_filter( 'manage_sites_custom_column',  'wp_user_profiles_filter_role_column', 10, 2 );
@@ -69,9 +68,6 @@ function wp_user_profiles_sites_metabox( $user = null ) {
 
 	// Output list table
 	$wp_list_table->display();
-
-	// Unfilter action links
-	remove_filter( 'manage_sites_action_links', 'wp_user_profiles_filter_sites_action_links' );
 
 	// After
 	do_action( __FUNCTION__ . '_after', $user );
@@ -102,38 +98,6 @@ function wp_user_profiles_filter_sites_table_query_args( $args = array() ) {
 
 	// Filter & return
 	return apply_filters( 'wp_user_profiles_filter_sites_table_query_args', $args );
-}
-
-/**
- * Unset some links if user cannot manage sites
- *
- * @since 1.0.0
- *
- * @param array $links
- * @return array
- */
-function wp_user_profiles_filter_sites_action_links( $links = array(), $blog_id = 0 ) {
-
-	if ( ! current_user_can( 'manage_sites' ) ) {
-		// Unset actionable links
-		unset(
-
-			// Core
-			$links['edit'],
-			$links['activate'],
-			$links['deactivate'],
-			$links['archive'],
-			$links['unarchive'],
-			$links['spam'],
-			$links['unspam'],
-			$links['delete'],
-
-			// WP Multi Network
-			$links['move']
-		);
-	}
-
-	return $links;
 }
 
 /**

--- a/wp-user-profiles/includes/sites-list-table.php
+++ b/wp-user-profiles/includes/sites-list-table.php
@@ -14,6 +14,27 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-ms-sites-list-table.php';
 class WP_User_Profiles_Sites_List_Table extends WP_MS_Sites_List_Table {
 
 	/**
+	 * Gets a list of columns.
+	 *
+	 * @return string[] Array of column heading names keyed by column ID.
+	 */
+	public function get_columns() {
+		$is_network_admin = current_user_can( 'manage_sites' );
+
+		$columns = array(
+			'cb'       => '<input type="checkbox" />',
+			'blogname' => __( 'URL', 'wp-user-profiles' ),
+			'users'    => __( 'Users', 'wp-user-profiles' ),
+		);
+
+		if ( $is_network_admin ) {
+			$columns['roles'] = esc_html__( 'Roles', 'wp-user-profiles' );
+		}
+
+		return $columns;
+	}
+
+	/**
 	 * Handles the checkbox column output.
 	 *
 	 * @param array $blog Current site.


### PR DESCRIPTION
When editing a user profile on a Multisite installation, the list table shown on the Sites tab still contains more information than it needs to. The main confusion we hear from clients is why there is unrelated information in this table, which ultimately comes from the fact that this list table is a Sites list table and we're using it as a Roles-on-Sites table.

This was simplified in #39 . This continues that by enforcing the columns that are shown in this table so it only shows the URL, number of users, and the user role. This prevents custom columns, for example those added by ElasticPress or MultilingualPress, from appearing in this view.

I've also removed some dead code that's unrelated to this change. The code that filters the action links should have been removed in #39 as it's no longer called.

## Before

<img width="1195" alt="" src="https://user-images.githubusercontent.com/208434/115011974-8b643e00-9eaf-11eb-9c10-3e162486aeaa.png">

## After

<img width="1193" alt="" src="https://user-images.githubusercontent.com/208434/115011968-8a331100-9eaf-11eb-8559-a5912c158320.png">
