### PR TITLE
Use WP core translation for menu item

### DIFF
--- a/wp-user-profiles/includes/admin.php
+++ b/wp-user-profiles/includes/admin.php
@@ -213,8 +213,8 @@ function wp_user_profiles_admin_menus() {
 
 		// Add the main page
 		add_menu_page(
-			esc_html__( 'Profile', 'wp-user-profiles' ),
-			esc_html__( 'Profile', 'wp-user-profiles' ),
+			esc_html__( 'Profile' ),
+			esc_html__( 'Profile' ),
 			'read',
 			'profile',
 			$callback,


### PR DESCRIPTION
There is a translation available for the slug "Profile" in WP core. I suggest using that to have the menu item translated even when the plugin is not.