### PR TITLE
Project: Add contributor and release-archive foundation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{css,js,php}]
+indent_style = tab
+indent_size = 4
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[composer.json]
+indent_style = space
+indent_size = 2
+
+[package.json]
+indent_style = tab
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+* text=auto eol=lf
+
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/.phpcs.xml.dist export-ignore
+/AGENTS.md export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md export-ignore
+/Gruntfile.js export-ignore
+/README.md export-ignore
+/SECURITY.md export-ignore
+/SUPPORT.md export-ignore
+/composer.json export-ignore
+/composer.lock export-ignore
+/package-lock.json export-ignore
+/package.json export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: Report a reproducible problem in WP User Profiles.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Report security vulnerabilities privately through GitHub Security Advisories.
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest reliable sequence that demonstrates the problem.
+    validations:
+      required: true
+  - type: input
+    id: plugin-version
+    attributes:
+      label: WP User Profiles version
+    validations:
+      required: true
+  - type: input
+    id: wordpress-version
+    attributes:
+      label: WordPress version
+    validations:
+      required: true
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP version
+    validations:
+      required: true
+  - type: dropdown
+    id: screen
+    attributes:
+      label: Affected profile screen
+      options:
+        - Your Profile
+        - Edit User
+        - Network Admin user profile
+        - User Admin profile
+        - Multiple profile screens
+    validations:
+      required: true
+  - type: dropdown
+    id: section
+    attributes:
+      label: Affected section
+      options:
+        - Profile
+        - Account
+        - Options
+        - Permissions
+        - Sites
+        - Other or third-party section
+        - Multiple sections
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Include active profile-related plugins and sanitized logs. Never include credentials or personal data.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: WordPress.org support
+    url: https://wordpress.org/support/plugin/wp-user-profiles/
+    about: Ask installation and usage questions in the public support forum.
+  - name: Security report
+    url: https://github.com/stuttter/wp-user-profiles/security/advisories/new
+    about: Report a suspected vulnerability privately.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Propose a focused improvement to WP User Profiles.
+title: "Enhancement: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem should this solve?
+      description: Describe the user-facing need before proposing an implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the observable behavior and compatibility expectations.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Affected area
+      options:
+        - Profile sections or navigation
+        - Profile fields or meta-boxes
+        - Roles, capabilities, or status
+        - Multisite Sites section
+        - Third-party plugin integration
+        - Developer API
+        - Multiple areas
+        - Unsure
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What changed
+
+Describe the observable change and why it belongs in WP User Profiles.
+
+## Risk and compatibility
+
+- [ ] Public functions, classes, hooks, filters, section IDs, and meta-box IDs remain compatible.
+- [ ] PHP 7.2 and WordPress 5.2 compatibility are preserved.
+- [ ] Self-editing, editing another user, and multisite impact is described where applicable.
+- [ ] Capability, nonce, role, status, privacy, dependency, automation, and release implications are identified.
+
+## Validation
+
+- [ ] Regression coverage was added or the reason it is unnecessary is stated.
+- [ ] Changed PHP files pass syntax checks on the supported PHP versions.
+- [ ] Affected profile screens and sections were checked manually.
+- [ ] Generated assets were rebuilt and reviewed when their sources changed.
+- [ ] The production artifact contains no development files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,154 @@
+# Changelog
+
+## Unreleased
+
+* Add integrations for the Two-Factor and User Switching plugins
+* Add selectable local and remote strategies for discovering roles across a
+  multisite network
+* Correct the password-nag link to open the Account section
+* Prevent users without the `promote_users` capability from changing roles
+* Improve PHP 8 compatibility for multisite role discovery
+* Allow the list of loaded plugin files to be filtered
+* Correct saving for syntax highlighting and profile validation errors
+* Fix dismissible administration notices
+* Update WordPress compatibility metadata and development dependencies
+
+## 2.6.2 (2021-08-18)
+
+* Correct role assignment when saving the Permissions section on multisite
+* Check `promote_users` in the context of each affected site
+* Prevent stale cached user data from being saved
+* Improve the Sites role list table
+* Show status dates in the user's timezone
+* Avoid a fatal error on WordPress versions without password reset emails
+* Load unminified assets when `SCRIPT_DEBUG` is enabled
+
+## 2.6.1 (2021-05-29)
+
+* Update author information and project links
+
+## 2.6.0 (2021-03-26)
+
+* Improve compatibility with the Classic Editor plugin
+* Correct translatable strings and text domains
+* Improve right-to-left styling
+* Add minified styles for production sites
+
+## 2.5.1 (2021-03-24)
+
+* Support password reset emails introduced in WordPress 5.7
+* Prevent unintended removal of super administrator privileges
+* Correct contact-method handling
+* Correct translatable strings
+
+## 2.5.0 (2020-11-12)
+
+* Support Application Passwords introduced in WordPress 5.6
+
+## 2.4.0 (2020-11-11)
+
+* Improve BuddyPress compatibility
+* Better match WordPress font sizing
+* Allow a user's role to be removed from a site
+* Add the section sub-navigation interface and API
+* Add actions after every meta-box display function
+
+## 2.3.1 (2020-10-07)
+
+* Clarify site action links
+
+## 2.3.0 (2020-10-07)
+
+* Allow non-administrators to select a language
+* Preserve a user's selected language instead of the site default
+* Add the language chooser icon
+
+## 2.2.1 (2020-07-07)
+
+* Correct compatibility with the Genesis theme
+
+## 2.2.0 (2020-05-06)
+
+* Improve general code quality and compatibility
+
+## 2.1.0 (2017-05-24)
+
+* Correct the `IS_PROFILE_PAGE` constant
+* Introduce `wp_is_profile_page()`
+
+## 2.0.0 (2017-05-18)
+
+* Apply the `edit` filter to user data
+* Add capability checks when editing users
+* Add the Other section for legacy profile fields
+
+## 1.2.0 (2017-01-26)
+
+* Use WordPress.org language packs for translations
+
+## 1.1.0 (2016-11-18)
+
+* Improve profile-saving security (props Brady Vercher)
+
+## 1.0.0 (2016-10-30)
+
+* Support installation as a must-use plugin
+* Add WordPress 4.7 compatibility
+* Improve section, meta-box, and field key sanitization
+* Add multisite Sites support
+* Add the Language account setting
+
+## 0.2.0 (2015-12-23)
+
+* Simplify meta-box registration
+* Add actions for meta-box sections
+* Introduce the `edit_profile` meta capability
+* Improve plugin load order
+* Improve network and user dashboard support
+* Prevent access to the replaced profile screens
+
+## 0.1.10 (2015-11-12)
+
+* Improve user dashboard support
+
+## 0.1.9 (2015-11-11)
+
+* Correct profile script loading in network and user dashboards
+
+## 0.1.8 (2015-11-11)
+
+* Repackage version 0.1.7 to correct documentation
+
+## 0.1.7 (2015-11-11)
+
+* Add network and user dashboard support
+* Improve WordPress 4.3 and 4.4 compatibility
+
+## 0.1.6 (2015-11-09)
+
+* Update plugin metadata
+
+## 0.1.5 (2015-10-23)
+
+* Support third-party sections
+* Show the status meta-box in every section
+
+## 0.1.4 (2015-10-21)
+
+* Update scripts and hook priorities
+
+## 0.1.3 (2015-10-15)
+
+* Support user-status updates
+
+## 0.1.2 (2015-10-15)
+
+* Update the plugin description
+
+## 0.1.1 (2015-10-15)
+
+* Update documentation
+
+## 0.1.0 (2015-10-15)
+
+* Publish the initial release

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of conduct
+
+## Our standard
+
+Be welcoming, patient, and respectful. Discuss ideas and behavior without
+attacking people. Assume good intent, accept constructive feedback, and help
+make participation safe for people of every background and experience level.
+
+Harassment, discrimination, threats, deliberate intimidation, sexualized
+attention, publishing private information, and sustained disruption are not
+acceptable.
+
+## Enforcement
+
+Report unacceptable behavior privately through the repository owner's GitHub
+profile. Maintainers may edit or remove contributions and temporarily or
+permanently restrict participation when necessary to protect the community.
+Reports will be handled as confidentially as practical.
+
+This policy applies in project spaces and when someone publicly represents the
+project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thanks for helping maintain WP User Profiles.
+
+## Before changing behavior
+
+Describe the observable behavior, compatibility expectations, and acceptance
+criteria in a GitHub issue. Report suspected vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/stuttter/wp-user-profiles/security/advisories/new).
+
+## Pull requests
+
+* Keep each pull request focused and reversible.
+* Add regression coverage for behavior changes and bug fixes when a suitable
+  test harness exists.
+* Preserve the declared PHP and WordPress minimum versions.
+* Test both self-editing and editing another user when the affected code
+  supports both.
+* Test single-site, multisite Network Admin, and User Admin behavior where
+  applicable.
+* Identify capability, nonce, role, status, privacy, dependency, and
+  release-process implications explicitly.
+* Rebuild and review generated assets when their sources change.
+* Do not commit credentials, build caches, development databases, or generated
+  release ZIP files.
+* Wait for every required check and resolve review conversations before merge.
+
+AI-assisted contributions are welcome, but the contributor remains responsible
+for understanding and validating the result.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+Use the [WordPress.org support forum](https://wordpress.org/support/plugin/wp-user-profiles/)
+for installation and usage questions. Use the GitHub issue tracker for
+reproducible defects and narrowly scoped enhancements, and GitHub Discussions
+for broader development conversations.
+
+Report suspected vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/stuttter/wp-user-profiles/security/advisories/new),
+not in a public issue.


### PR DESCRIPTION
WP User Profiles has accumulated substantial unreleased work since 2.6.2, but the repository does not yet have the contributor and archive foundation needed to review or package that work safely.

This adds the non-runtime project surface first:

- a changelog reconstructed from published tags and post-2.6.2 Git history
- contribution, support, and community conduct guidance
- issue forms tailored to profile sections, multisite, roles, capabilities, and integrations
- a pull-request checklist grounded in the plugin's current risks
- consistent editor and line-ending rules
- an explicit production export surface

The release archive now contains only the license, readme, changelog, plugin loader, and the complete runtime/assets tree. It excludes GitHub metadata, contributor docs, tests, dependency manifests, and build inputs.

This deliberately does not add or change runtime code, dependencies, workflows, release/security policy, ownership, or `AGENTS.md`. PHPUnit and WordPress integration coverage belong in the next focused change.

Validation:

- Composer configuration validates strictly
- all issue-form YAML parses successfully
- staged whitespace validation passes
- every new text file is UTF-8, LF-only, and ends with a newline
- the production archive contains 64 intended paths, including `CHANGELOG.md`, with no development paths
- the commit is signed and must be GitHub-verified before merge
