### PR TITLE
Synchronize shared plugin standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Managed by stuttter/.github fleet standards. Do not edit locally.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies

--- a/.github/plugin-standard.json
+++ b/.github/plugin-standard.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/stuttter/.github/main/schema/plugin-standard.schema.json",
+  "slug": "wp-user-profiles",
+  "main_file": "wp-user-profiles.php",
+  "risk": "critical",
+  "minimum_php": "7.4",
+  "minimum_wordpress": "5.2",
+  "tested_wordpress": "7.1",
+  "wordpress_org": true,
+  "multisite": true,
+  "release_branch": "master",
+  "php_matrix": [
+    "7.4",
+    "8.0",
+    "8.2",
+    "8.4"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+# Managed by stuttter/.github fleet standards. Do not edit locally.
+name: Plugin CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    uses: stuttter/.github/.github/workflows/wordpress-plugin-ci.yml@e8c938f2ed5b71517d4a2966e382e3d362a5f029
+    with:
+      php-versions: '["7.4","8.0","8.2","8.4"]'
+      quality-php-version: '8.4'


### PR DESCRIPTION
Adds or updates only files explicitly owned by the Stuttter fleet standard. Repository-owned files are never overwritten. Review and full CI are required before merge.